### PR TITLE
fix callerMonthsLapsed to not return NaN if never called

### DIFF
--- a/src/_util/caller.js
+++ b/src/_util/caller.js
@@ -23,12 +23,12 @@ const isWaiting = ({ lastCallTimestamp, created }) => {
 }
 
 
-const callerMonthsLapsed = ({ lastCallTimestamp, lastReminderTimestamp }) => {
-    const lastCallDate = DateTime.fromSQL(lastCallTimestamp)
+const callerMonthsLapsed = ({ lastCallTimestamp, lastReminderTimestamp, created }) => {
+    const lastCallDate = lastCallTimestamp !== null ? DateTime.fromSQL(lastCallTimestamp) : DateTime.fromSQL(created)
     const lastReminderDate = DateTime.fromSQL(lastReminderTimestamp) 
     const lapseDuration = lastReminderDate.diff(lastCallDate)
-
-    return Math.floor(lapseDuration.as('months'))
+    const numMonths = Math.floor(lapseDuration.as('months'))
+    return numMonths
 }
 
 export const Status = {

--- a/src/_util/caller.js
+++ b/src/_util/caller.js
@@ -14,21 +14,34 @@ const isCurrent = ({ lastCallTimestamp, lastReminderTimestamp }) => {
     return lastCallDateTime.diff(lastReminderDateTime) >= 0
 }
 
-const isWaiting = ({ lastCallTimestamp, created }) => {
-    const lastCallDateTime = DateTime.fromSQL(lastCallTimestamp || created)
+const isWaiting = ({ lastReminderTimestamp, created }) => {
+    const lastReminderDateTime = DateTime.fromSQL(lastReminderTimestamp || created)
     const now = DateTime.local()
-    const daysSinceLastNotification = now.diff(lastCallDateTime).as('days')
+    const daysSinceLastNotification = now.diff(lastReminderDateTime).as('days')
 
     return daysSinceLastNotification <= WAIT_FOR_CALL_AFTER_NOTIFICATION_DAYS
 }
 
 
 const callerMonthsLapsed = ({ lastCallTimestamp, lastReminderTimestamp, created }) => {
-    const lastCallDate = lastCallTimestamp !== null ? DateTime.fromSQL(lastCallTimestamp) : DateTime.fromSQL(created)
+    const lastCallDate = DateTime.fromSQL(lastCallTimestamp || created)
     const lastReminderDate = DateTime.fromSQL(lastReminderTimestamp) 
     const lapseDuration = lastReminderDate.diff(lastCallDate)
     const numMonths = Math.floor(lapseDuration.as('months'))
     return numMonths
+}
+
+export const sortedByStatus = (a, b) => {
+    const orderedList = [Status.CURRENT, Status.WAITING, Status.BRAND_NEW, Status.PAUSED, Status.LAPSED];   
+    const aIndex = orderedList.indexOf(a.status.status);
+    const bIndex = orderedList.indexOf(b.status.status);       
+    const aScore = aIndex === -1 ? orderedList.length : aIndex;
+    const bScore = bIndex === -1 ? orderedList.length : bIndex;
+    const diff = aScore - bScore;
+    if (diff !== 0 || a.status.status !== Status.LAPSED) {
+        return diff;
+    }
+    return a.status.monthsMissedCount - b.status.monthsMissedCount;
 }
 
 export const Status = {

--- a/src/_util/caller.test.js
+++ b/src/_util/caller.test.js
@@ -1,0 +1,84 @@
+import { DateTime} from 'luxon'
+import { cloneDeep } from 'lodash'
+
+const callers = require('../fixtures/callers.json');
+const { callerStatus, Status, sortedByStatus } = require('./caller')
+
+const _allCallers = callers.map(caller => {
+    return {
+        ...caller,
+        status: callerStatus(caller),
+      }
+});
+
+const _currentCaller = _allCallers.find((el) => {
+    return el.status.status == Status.CURRENT
+});
+
+const _firstLapsedCaller = _allCallers.find((el) => {
+    return el.status.status == Status.LAPSED
+});
+
+const _recentlyLapsedCaller = cloneDeep(_allCallers).reverse().find((el) => {
+    return el.status.status == Status.LAPSED
+});
+
+const _pausedCaller = _allCallers.find((el) => {
+    return el.status.status == Status.PAUSED
+});
+
+const _brandNewCaller = _allCallers.find((el) => {
+    return el.status.status == Status.BRAND_NEW
+});
+
+const _waitingCallerFunc = () => {
+    const waiting = cloneDeep(_firstLapsedCaller)
+    waiting.status.status = Status.WAITING
+    waiting.lastReminderTimestamp = DateTime.local().toSQL()
+    return waiting
+}
+
+const _waitingCaller = _waitingCallerFunc()
+
+describe('sortedByStatus', () => {
+
+    test('current comes before lapsed', () => {
+        expect(sortedByStatus(_currentCaller, _firstLapsedCaller)).toBeLessThan(0);
+    });
+
+    test('current comes before paused', () => {
+        expect(sortedByStatus(_currentCaller, _pausedCaller)).toBeLessThan(0);
+    });
+
+    test('current comes before brand new', () => {
+        expect(sortedByStatus(_currentCaller, _brandNewCaller)).toBeLessThan(0);
+    });
+
+    test('current comes before waiting', () => {
+        expect(sortedByStatus(_currentCaller, _waitingCaller)).toBeLessThan(0);
+    });
+
+    test('waiting comes before lapsed', () => {
+        expect(sortedByStatus(_waitingCaller, _firstLapsedCaller)).toBeLessThan(0);
+    });
+
+    test('waiting comes before paused', () => {
+        expect(sortedByStatus(_waitingCaller, _pausedCaller)).toBeLessThan(0);
+    });
+
+    test('waiting comes before brand new', () => {
+        expect(sortedByStatus(_waitingCaller, _brandNewCaller)).toBeLessThan(0);
+    });
+
+    test('paused comes before lapsed', () => {
+        expect(sortedByStatus(_pausedCaller, _firstLapsedCaller)).toBeLessThan(0);
+    });
+
+    test('recently lapsed comes before old lapsed', () => {
+        expect(sortedByStatus(_recentlyLapsedCaller, _firstLapsedCaller)).toBeLessThan(0);
+    });
+
+    test('same statuses are equal', () => {
+        expect(sortedByStatus(_currentCaller, _currentCaller)).toBe(0);
+    });
+});

--- a/src/containers/Callers/Callers.js
+++ b/src/containers/Callers/Callers.js
@@ -52,7 +52,6 @@ class Callers extends Component {
       dataIndex: 'status',
       key: 'status',
       render: (status) => {
-        console.log(status)
         return this.callStatusIcon(status);
       },
       sorter: (a, b) => {

--- a/src/containers/Callers/Callers.js
+++ b/src/containers/Callers/Callers.js
@@ -48,24 +48,25 @@ class Callers extends Component {
       key: 'reminderDayOfMonth',
       sorter: (a, b) => { return a.reminderDayOfMonth - b.reminderDayOfMonth}
     },{
-        title: 'Call Status',
-        dataIndex: 'status',
-        key: 'status',
-        render: (status) => {
-          return this.callStatusIcon(status);
-        },
-        sorter: (a, b) => {
-          const orderedList = [Status.CURRENT, Status.WAITING, Status.BRAND_NEW, Status.PAUSED, Status.LAPSED];   
-          const aIndex = orderedList.indexOf(a.status.status);
-          const bIndex = orderedList.indexOf(b.status.status);       
-          const aScore = aIndex === -1 ? orderedList.length : aIndex;
-          const bScore = bIndex === -1 ? orderedList.length : bIndex;
-          const diff = aScore - bScore;
-          if (diff !== 0 || a.status.status !== Status.LAPSED) {
-            return diff;
-          }
-          return a.status.monthsMissedCount - b.status.monthsMissedCount;
+      title: 'Call Status',
+      dataIndex: 'status',
+      key: 'status',
+      render: (status) => {
+        console.log(status)
+        return this.callStatusIcon(status);
+      },
+      sorter: (a, b) => {
+        const orderedList = [Status.CURRENT, Status.WAITING, Status.BRAND_NEW, Status.PAUSED, Status.LAPSED];   
+        const aIndex = orderedList.indexOf(a.status.status);
+        const bIndex = orderedList.indexOf(b.status.status);       
+        const aScore = aIndex === -1 ? orderedList.length : aIndex;
+        const bScore = bIndex === -1 ? orderedList.length : bIndex;
+        const diff = aScore - bScore;
+        if (diff !== 0 || a.status.status !== Status.LAPSED) {
+          return diff;
         }
+        return a.status.monthsMissedCount - b.status.monthsMissedCount;
+      }
     },{
         title: 'Details',
         dataIndex: 'operation1',

--- a/src/containers/Callers/Callers.js
+++ b/src/containers/Callers/Callers.js
@@ -6,7 +6,7 @@ import _ from 'lodash'
 import { DateTime } from 'luxon'
 import axios from '../../_util/axios-api';
 import { isSenatorDistrict } from '../../_util/district';
-import { callerStatus, Status } from '../../_util/caller';
+import { callerStatus, Status, sortedByStatus } from '../../_util/caller';
 import { HistoryType } from './constants'
 
 import { authHeader } from '../../_util/auth/auth-header';
@@ -54,18 +54,7 @@ class Callers extends Component {
       render: (status) => {
         return this.callStatusIcon(status);
       },
-      sorter: (a, b) => {
-        const orderedList = [Status.CURRENT, Status.WAITING, Status.BRAND_NEW, Status.PAUSED, Status.LAPSED];   
-        const aIndex = orderedList.indexOf(a.status.status);
-        const bIndex = orderedList.indexOf(b.status.status);       
-        const aScore = aIndex === -1 ? orderedList.length : aIndex;
-        const bScore = bIndex === -1 ? orderedList.length : bIndex;
-        const diff = aScore - bScore;
-        if (diff !== 0 || a.status.status !== Status.LAPSED) {
-          return diff;
-        }
-        return a.status.monthsMissedCount - b.status.monthsMissedCount;
-      }
+      sorter: sortedByStatus
     },{
         title: 'Details',
         dataIndex: 'operation1',

--- a/src/fixtures/callers.json
+++ b/src/fixtures/callers.json
@@ -1,0 +1,244 @@
+[
+    {
+        "created": "2019-05-08 05:27",
+        "lastModified": "2020-02-20 17:00",
+        "callerId": 4322,
+        "firstName": "Nachum",
+        "lastName": "Tahari",
+        "contactMethods": [
+            "email"
+        ],
+        "phone": "5125558888",
+        "email": "bla@bla.bla",
+        "districtId": 8,
+        "zipCode": 20001,
+        "paused": false,
+        "reminderDayOfMonth": 23,
+        "cclId": "blablaa2",
+        "referrer": null,
+        "lastReminderTimestamp": "2020-02-24 17:24",
+        "lastCallTimestamp": "2020-02-24 19:05"
+    },
+    {
+        "created": "2019-05-21 14:11",
+        "lastModified": "2019-12-23 16:42",
+        "callerId": 753,
+        "firstName": "Yoyo",
+        "lastName": "Nelson",
+        "contactMethods": [
+            "email"
+        ],
+        "phone": null,
+        "email": "bla2@bla.bla",
+        "districtId": 11,
+        "zipCode": 20001,
+        "paused": false,
+        "reminderDayOfMonth": 4,
+        "cclId": "blablaa3",
+        "referrer": null,
+        "lastReminderTimestamp": "2020-02-04 17:16",
+        "lastCallTimestamp": "2019-12-04 21:35"
+    },
+    {
+        "created": "2019-05-21 15:16",
+        "lastModified": "2019-12-23 16:42",
+        "callerId": 452,
+        "firstName": "Stephen",
+        "lastName": "Rauschmayer",
+        "contactMethods": [
+            "email"
+        ],
+        "phone": null,
+        "email": "bla3@bla.bla",
+        "districtId": 11,
+        "zipCode": 20001,
+        "paused": false,
+        "reminderDayOfMonth": 5,
+        "cclId": "blablaa",
+        "referrer": null,
+        "lastReminderTimestamp": "2020-02-05 17:16",
+        "lastCallTimestamp": "2019-10-07 15:39"
+    },
+    {
+        "created": "2019-05-21 17:58",
+        "lastModified": "2019-12-23 16:42",
+        "callerId": 777,
+        "firstName": "Wilson",
+        "lastName": "Marco",
+        "contactMethods": [
+            "email"
+        ],
+        "phone": null,
+        "email": "bla4@bla.bla",
+        "districtId": 11,
+        "zipCode": 20001,
+        "paused": false,
+        "reminderDayOfMonth": 6,
+        "cclId": "blablaa",
+        "referrer": null,
+        "lastReminderTimestamp": "2020-02-06 17:16",
+        "lastCallTimestamp": "2019-11-06 20:45"
+    },
+    {
+        "created": "2019-05-24 16:15",
+        "lastModified": "2020-02-13 18:47",
+        "callerId": 111,
+        "firstName": "Dean",
+        "lastName": "Lee",
+        "contactMethods": [
+            "email"
+        ],
+        "phone": null,
+        "email": "bla5@bla.bla",
+        "districtId": 11,
+        "zipCode": 20001,
+        "paused": true,
+        "reminderDayOfMonth": 7,
+        "cclId": "blablaa",
+        "referrer": null,
+        "lastReminderTimestamp": "2019-12-09 14:49",
+        "lastCallTimestamp": "2019-11-07 15:39"
+    },
+    {
+        "created": "2019-05-28 12:35",
+        "lastModified": "2019-05-28 12:35",
+        "callerId": 222,
+        "firstName": "Byrant",
+        "lastName": "OHallaron",
+        "contactMethods": [
+            "sms"
+        ],
+        "phone": "5125554444",
+        "email": null,
+        "districtId": 10,
+        "zipCode": 20001,
+        "paused": false,
+        "reminderDayOfMonth": 8,
+        "cclId": null,
+        "referrer": null,
+        "lastReminderTimestamp": "2020-02-10 17:16",
+        "lastCallTimestamp": null
+    },
+    {
+        "created": "2019-05-29 14:13",
+        "lastModified": "2019-12-23 16:42",
+        "callerId": 666,
+        "firstName": "Llama",
+        "lastName": "Ferry",
+        "contactMethods": [
+            "sms",
+            "email"
+        ],
+        "phone": "5125558822",
+        "email": "bla6@bla.bla",
+        "districtId": 509,
+        "zipCode": 20001,
+        "paused": false,
+        "reminderDayOfMonth": 2,
+        "cclId": "blablaa",
+        "referrer": null,
+        "lastReminderTimestamp": "2020-02-03 16:34",
+        "lastCallTimestamp": "2019-09-05 19:48"
+    },
+    {
+        "created": "2019-05-30 12:57",
+        "lastModified": "2019-12-23 16:42",
+        "callerId": 233,
+        "firstName": "Preston",
+        "lastName": "Bates",
+        "contactMethods": [
+            "email"
+        ],
+        "phone": null,
+        "email": "bla7@bla.bla",
+        "districtId": 535,
+        "zipCode": 20001,
+        "paused": false,
+        "reminderDayOfMonth": 4,
+        "cclId": "blablaa",
+        "referrer": null,
+        "lastReminderTimestamp": "2020-02-04 17:16",
+        "lastCallTimestamp": "2020-02-07 15:38"
+    },
+    {
+        "created": "2019-05-30 22:45",
+        "lastModified": "2019-12-23 16:42",
+        "callerId": 533,
+        "firstName": "Sierra",
+        "lastName": "Miles",
+        "contactMethods": [
+            "email"
+        ],
+        "phone": null,
+        "email": "bla8@bla.bla",
+        "districtId": 815,
+        "zipCode": 20001,
+        "paused": false,
+        "reminderDayOfMonth": 5,
+        "cclId": "blablaa",
+        "referrer": null,
+        "lastReminderTimestamp": "2020-02-05 17:16",
+        "lastCallTimestamp": null
+    },
+    {
+        "created": "2019-05-30 22:46",
+        "lastModified": "2019-12-23 16:42",
+        "callerId": 142,
+        "firstName": "Wilder",
+        "lastName": "Morse",
+        "contactMethods": [
+            "email"
+        ],
+        "phone": null,
+        "email": "bla9@bla.bla",
+        "districtId": 432,
+        "zipCode": 20001,
+        "paused": false,
+        "reminderDayOfMonth": 6,
+        "cclId": "blablaa",
+        "referrer": null,
+        "lastReminderTimestamp": "2020-02-06 17:16",
+        "lastCallTimestamp": "2020-02-11 04:35"
+    },
+    {
+        "created": "2019-05-30 22:47",
+        "lastModified": "2019-12-23 16:42",
+        "callerId": 131,
+        "firstName": "Haran",
+        "lastName": "Zvi",
+        "contactMethods": [
+            "email"
+        ],
+        "phone": null,
+        "email": "bla10@bla.bla",
+        "districtId": 815,
+        "zipCode": 20001,
+        "paused": false,
+        "reminderDayOfMonth": 7,
+        "cclId": "blablaa",
+        "referrer": null,
+        "lastReminderTimestamp": "2020-02-07 17:16",
+        "lastCallTimestamp": "2020-01-07 20:14"
+    },
+    {
+        "created": "2020-02-25 02:42",
+        "lastModified": "2020-02-25 02:42",
+        "callerId": 654,
+        "firstName": "Thor",
+        "lastName": "Thompsen",
+        "contactMethods": [
+            "email",
+            "sms"
+        ],
+        "phone": "5128889999",
+        "email": "bla12@bla.bla",
+        "districtId": 529,
+        "zipCode": "78055",
+        "paused": false,
+        "reminderDayOfMonth": 11,
+        "cclId": null,
+        "referrer": "CCL Main Site",
+        "lastReminderTimestamp": null,
+        "lastCallTimestamp": null
+    }
+]


### PR DESCRIPTION
`callerMonthsLapsed` was using the last call timestamp as the beginning of time for measuring lapse. What if the caller never made a single call? Then we should default to sign up date (if we were being really fancy, we'd probably go back to first notification date, but the precision is not important). 

In callers.js, just making indentation consistent