### PR TITLE
Prevent lapsed callers from appearing as "waiting to call"

### DIFF
--- a/src/_util/caller.test.js
+++ b/src/_util/caller.test.js
@@ -1,6 +1,9 @@
-import { DateTime} from 'luxon'
+import { Settings, DateTime} from 'luxon'
 import { cloneDeep } from 'lodash'
 
+
+const mockNow = DateTime.fromSQL("2020-03-05").toMillis();
+Settings.now = () => mockNow;
 
 const callers = require('../fixtures/callers.json');
 const { callerStatus, Status, sortedByStatus, asCsv } = require('./caller')
@@ -32,14 +35,28 @@ const _brandNewCaller = _allCallers.find((el) => {
     return el.status.status == Status.BRAND_NEW
 });
 
-const _waitingCallerFunc = () => {
-    const waiting = cloneDeep(_firstLapsedCaller)
-    waiting.status.status = Status.WAITING
-    waiting.lastReminderTimestamp = DateTime.local().toSQL()
-    return waiting
-}
+const [_waitingNewCaller, _waitingCurrentCaller, _waitingLapsedCaller] = (
+    [_brandNewCaller, _currentCaller, _firstLapsedCaller].map(caller => {
+        const waiting = cloneDeep(caller)
+        waiting.lastReminderTimestamp = DateTime.local().minus({days: 2}).toSQL()
+        waiting.status = callerStatus(waiting)
+        return waiting
+    })
+)
 
-const _waitingCaller = _waitingCallerFunc()
+describe('statusPrecedence', () => {
+    test('waiting hides new', () => {
+        expect(_waitingNewCaller.status.status).toBe(Status.WAITING);
+    });
+    test('waiting hides current', () => {
+        expect(_waitingCurrentCaller.status.status).toBe(Status.WAITING);
+    });
+    test('lapsed hides waiting', () => {
+        expect(_waitingLapsedCaller.status.status).toBe(Status.LAPSED);
+    });
+});
+
+const _waitingCaller = _waitingCurrentCaller;
 
 describe('sortedByStatus', () => {
 


### PR DESCRIPTION
If a caller has received a recent reminder, they are "waiting to call".
If they haven't called since their latest (non-recent) reminder, they are
"lapsed". If both conditions hold, they were being listed as "waiting",
but will now be listed as "lapsed".

There's an anomaly when a caller returns from a paused hiatus.
Assuming the caller was "current" before pausing, they will still appear
"current" when the pause is ended. But then they receive a reminder and
their status changes to "lapsed" instead of "waiting". The client thinks
their most recent call was too long ago. It doesn't know that they were
previously paused and received no notifications during the pause.

One way to fix this would be to add a "previousReminderTimestamp"
field to the callers API response. Then the client could always tell
whether the caller's most recent call was after the corresponding
reminder. Without that information, the client just assumes the
previous reminder came one month before the recent one, which
is not the case when the caller was paused.

If the anomaly does not seem too problematic, it should be OK to
pull this branch as is.