### PR TITLE
Talking Points improvements

### DIFF
--- a/src/containers/TalkingPoints/TalkingPoints.js
+++ b/src/containers/TalkingPoints/TalkingPoints.js
@@ -24,6 +24,7 @@ class TalkingPoints extends Component {
         editing: null,
         wantsToAddNewTalkingPoint: false,
         admins: null,
+        adminsById: null,
         editingTalkingPointDetails: null
     }
 
@@ -64,6 +65,7 @@ class TalkingPoints extends Component {
             
             Promise.all([getAdmins, getTPs, getThemes, getLiveTPs]).then((response)=>{
                 const admins = response[0].data;
+                const adminsById = new Map(admins.map((el) => [el.adminId, el]));
                 const talkingPoints = response[1].data;
                 const themes = response[2].data;
                 const liveTPs = response[3].data;
@@ -80,6 +82,7 @@ class TalkingPoints extends Component {
                 this.setState({
                     allTalkingPoints: sortedTPs,
                     admins: admins,
+                    adminsById: adminsById,
                     themes: themes,
                     liveTalkingPoints: liveTPs
                 }, () => {
@@ -177,7 +180,7 @@ class TalkingPoints extends Component {
         }).filter((el)=>{
             if (filters && filters.author) {
                 const author = filters.author.trim().toLowerCase();
-                const createdBy = this.state.admins.find((admin) => admin.adminId === el.createdBy);
+                const createdBy = el.createdBy && this.state.adminsById.get(el.createdBy);
                 if (!createdBy) {
                     return false;
                 }
@@ -495,9 +498,7 @@ class TalkingPoints extends Component {
                 const theme = this.state.themes.find((el) => {
                     return el.themeId === item.themeId
                 });
-                const createdBy = this.state.admins.find((el)=> {
-                    return el.adminId === item.createdBy
-                })
+                const createdBy = item.createdBy && this.state.adminsById.get(item.createdBy);
 
                 const reference = item.referenceUrl ?
                     <Typography.Text copyable={{ text: item.referenceUrl }}>
@@ -548,6 +549,7 @@ class TalkingPoints extends Component {
             && this.props.districts.length > 0
             && this.state.liveTalkingPoints !== null
             && this.state.admins !== null
+            && this.state.adminsById !== null
     }
 }
 

--- a/src/containers/TalkingPoints/TalkingPoints.js
+++ b/src/containers/TalkingPoints/TalkingPoints.js
@@ -175,6 +175,19 @@ class TalkingPoints extends Component {
             }
             return true;
         }).filter((el)=>{
+            if (filters && filters.author) {
+                const author = filters.author.trim().toLowerCase();
+                const createdBy = this.state.admins.find((admin) => admin.adminId === el.createdBy);
+                if (!createdBy) {
+                    return false;
+                }
+                return (
+                    createdBy.userName.toLowerCase().includes(author) ||
+                    (createdBy.email && createdBy.email.toLowerCase().includes(author))
+                );
+            }
+            return true;
+        }).filter((el)=>{
             if (this.state.searchTerm){
                 return el.content.toLowerCase().includes(this.state.searchTerm.toLowerCase())
             }
@@ -358,7 +371,7 @@ class TalkingPoints extends Component {
                     </Col>
                 </Row>
                 <Row gutter={[{ xs: 8, sm: 16, md: 24, lg: 32 }, 20]}>
-                    <Col sm={24} md={8} >
+                    <Col sm={24} md={6} >
                         <Form.Item label="Relevance">
                             {getFieldDecorator("scope", {})(
                                 <Checkbox.Group>
@@ -369,7 +382,7 @@ class TalkingPoints extends Component {
                             )}
                         </Form.Item>
                     </Col>
-                    <Col sm={24} md={8} >
+                    <Col sm={24} md={6} >
                         <Form.Item label="Theme">
                         {getFieldDecorator("theme", {})(
                             <Select
@@ -385,12 +398,19 @@ class TalkingPoints extends Component {
                             )}
                         </Form.Item>
                     </Col>
-                    <Col sm={24} md={8} >
-                        <Form.Item label="Currently selected for Call-In Script">
+                    <Col sm={24} md={6} >
+                        <Form.Item label="Currently selected">
                             {getFieldDecorator("script", {
                                 valuePropName: 'checked'
                             })(
                                 <Checkbox value={"script"}>In Script</Checkbox>
+                            )}
+                        </Form.Item>
+                    </Col>
+                    <Col sm={24} md={6} >
+                        <Form.Item label="Author">
+                            {getFieldDecorator("author", {})(
+                                <Input placeholder="Username or email" />
                             )}
                         </Form.Item>
                     </Col>

--- a/src/containers/TalkingPoints/TalkingPoints.js
+++ b/src/containers/TalkingPoints/TalkingPoints.js
@@ -68,6 +68,7 @@ class TalkingPoints extends Component {
                 const adminsById = new Map(admins.map((el) => [el.adminId, el]));
                 const talkingPoints = response[1].data;
                 const themes = response[2].data;
+                const sortedThemes = themes.sort((el1, el2) => el1.name.localeCompare(el2.name));
                 const liveTPs = response[3].data;
                 const sortedTPs = talkingPoints.sort((el1, el2)=>{
                     const d1 = new Date(el1.created)
@@ -83,7 +84,7 @@ class TalkingPoints extends Component {
                     allTalkingPoints: sortedTPs,
                     admins: admins,
                     adminsById: adminsById,
-                    themes: themes,
+                    themes: sortedThemes,
                     liveTalkingPoints: liveTPs
                 }, () => {
                     this.setState({


### PR DESCRIPTION
This pull addresses Trello cards "9 - Search for Talking Point by Author" and "9.1 - Alphabetize Themes".

Note that I shortened the label "Currently selected for Call-In Script" to just "Currently selected", so that it wouldn't overflow its bounding box. It was already overflowing the box a little bit, but with the addition of a new form field, it would overflow to the point of illegibility. Would it be preferable to keep the long label and make it wrap? I tried using `white-space: normal` as suggested [here](https://github.com/ant-design/ant-design/issues/5285) but then it left too much vertical space between the lines.