### PR TITLE
Fix navigation bugs

### DIFF
--- a/src/containers/CallDistribution/CallDistribution.js
+++ b/src/containers/CallDistribution/CallDistribution.js
@@ -7,7 +7,13 @@ import { authHeader } from '../../_util/auth/auth-header';
 
 import styles from './CallDistribution.module.css';
 
-import { isSenatorDistrict, getAssociatedSenators, displayName, comparator as districtComparator } from '../../_util/district';
+import {
+    isSenatorDistrict,
+    getAssociatedSenators,
+    displayName,
+    comparator as districtComparator,
+    slug as districtSlug
+} from '../../_util/district';
 
 class CallDistribution extends Component {
 
@@ -227,7 +233,7 @@ class CallDistribution extends Component {
 
     render = () => {
         if (isSenatorDistrict(this.props.district)) {
-            return <Redirect to='/script'/>;
+            return <Redirect to={`/script/${districtSlug(this.props.district)}`} />;
         }
         return <>
             {this.header()}

--- a/src/containers/Callers/Callers.js
+++ b/src/containers/Callers/Callers.js
@@ -19,7 +19,7 @@ import {
   getDistrictCallers,
   getCallerHistories,
 } from "../../_util/axios-api";
-import { isSenatorDistrict } from "../../_util/district";
+import { isSenatorDistrict, slug as districtSlug } from "../../_util/district";
 import { asCsv, sortedByStatus, Status } from "../../_util/caller";
 
 import { connect } from "react-redux";
@@ -378,7 +378,7 @@ class Callers extends Component {
 
   render() {
     if (isSenatorDistrict(this.props.district)) {
-      return <Redirect to="/script" />;
+      return <Redirect to={`/script/${districtSlug(this.props.district)}`} />;
     }
 
     return (

--- a/src/containers/Script/Script.js
+++ b/src/containers/Script/Script.js
@@ -5,7 +5,7 @@ import get from "lodash/get"
 import { Button, Card, Icon, Input, List, Modal, message, Skeleton, Form, Popconfirm, Typography, Spin} from 'antd';
 
 import axios from '../../_util/axios-api';
-import { displayName } from '../../_util/district';
+import { displayName, slug as districtSlug } from '../../_util/district';
 import { authHeader } from '../../_util/auth/auth-header';
 
 class Script extends Component {
@@ -271,11 +271,12 @@ class Script extends Component {
     }
 
     actions = () => {
+        const talkingPointsURL = `/talking-points/${districtSlug(this.props.district)}`;
         return (
             <Skeleton loading={this.state.hydratedDistrict === null}>
                 {this.state.hydratedDistrict &&
                 <div style={{padding: "10px", display: "flex", justifyContent: "center"}}>
-                    <Button style={{marginRight: "5px"}} ><Link to="/talking-points">Add a Talking Point</Link></Button>
+                    <Button style={{marginRight: "5px"}} ><Link to={talkingPointsURL}>Add a Talking Point</Link></Button>
                     <Button style={{marginLeft: "5px"}} target="_blank" href={`http://www.cclcalls.org/call/${this.state.hydratedDistrict.state.toLowerCase()}/${this.state.hydratedDistrict.number}`}>View the Live Script</Button>
                 </div>}
             </Skeleton>

--- a/src/containers/TalkingPoints/TalkingPoints.js
+++ b/src/containers/TalkingPoints/TalkingPoints.js
@@ -7,6 +7,7 @@ import get from "lodash/get"
 
 import axios from '../../_util/axios-api';
 import { authHeader } from '../../_util/auth/auth-header';
+import { slug as districtSlug } from "../../_util/district";
 import AddEditTalkingPointModal from './AddEditTalkingPointModal'
 
 import './TalkingPoints.module.css';
@@ -469,6 +470,7 @@ class TalkingPoints extends Component {
                 headers: { ...authHeader(), 'Content-Type': 'application/json' },
                 data: newScript
             };
+            const scriptURL = `/script/${districtSlug(this.props.district)}`;
             axios(updateScriptRequestOptions).then((response)=>{
                 Modal.confirm({
                     title: 'View Updated Script?',
@@ -477,7 +479,7 @@ class TalkingPoints extends Component {
                     cancelText: 'No',
                     onOk() {
                         self.setState({
-                            redirect: "/script"
+                            redirect: scriptURL
                         })
                     }
                 });


### PR DESCRIPTION
When updating the site navigation to store selected district in URL
instead of Redux state, some internal redirects and links were left using
the old-style URL without district info. Following these redirects was
causing the district selection to snap back to the first one in the list.