### PR TITLE
Call history recipient

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "terser": "^3.17.0"
   },
   "jest": {
-      "setupFiles": ["<rootDir>/src/jest/axios-mock.js"]
+    "setupFiles": [
+      "<rootDir>/src/jest/axios-mock.js"
+    ]
   }
 }

--- a/src/_util/axios-api.js
+++ b/src/_util/axios-api.js
@@ -98,8 +98,8 @@ function getCallerHistory(caller, districtsById) {
     const signUpHistory = [
       createHistoryItem({timestamp: caller.created, type: HistoryType.SIGN_UP}),
     ];
-    const callHistory = _.map(calls.data, ({ created }) =>
-      createHistoryItem({timestamp: created, type: HistoryType.CALL})
+    const callHistory = _.map(calls.data, ({ created, districtId }) =>
+      createHistoryItem({timestamp: created, type: HistoryType.CALL, districtId})
     );
     const reminderHistory = _.map(reminders.data, ({ timeSent, targetDistrictId, trackingId }) => {
       const district = districtsById.get(targetDistrictId);

--- a/src/containers/Callers/CallerDetailModal.js
+++ b/src/containers/Callers/CallerDetailModal.js
@@ -33,7 +33,7 @@ class CallerDetailModal extends Component {
         const caller = this.props.caller && this.props.caller.caller;
         return (
             <Skeleton active loading={!history || !caller}>
-                <HistoryPanel history={history} caller={caller} />
+                <HistoryPanel history={history} caller={caller} districtsById={this.props.districtsById} />
             </Skeleton>
         )
     }

--- a/src/containers/Callers/Callers.js
+++ b/src/containers/Callers/Callers.js
@@ -303,6 +303,7 @@ class Callers extends Component {
       <CallerDetailModal
         caller={this.state.callerDetail}
         display={caller != null}
+        districtsById={this.props.districtsById}
         onEditCaller={(callerDetails) => {
           this.onEditCaller(callerDetails);
         }}

--- a/src/containers/Callers/Callers.test.js
+++ b/src/containers/Callers/Callers.test.js
@@ -2,6 +2,7 @@ import React from "react"
 import { render } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import Callers from "./Callers"
+import HistoryPanel from "./HistoryPanel"
 import {
     getAllCallers,
     getDistrictCallers,
@@ -27,21 +28,28 @@ const JR_SEN_DISTRICT = {
     state: "MI",
     number: -2,
     districtId: 0,
+    repFirstName: 'Paul',
+    repLastName: 'Mingus'
 };
 
 const SR_SEN_DISTRICT = {
     state: "MI",
     number: -1,
     districtId: 1,
+    repFirstName: 'Xerbi',
+    repLastName: 'Qaraq'
 };
 
 const REP_DISTRICT = {
     state: "MI",
     number: 1,
     districtId: 2,
+    repFirstName: 'Neysa',
+    repLastName: 'Sheen'
 };
 
 const districtsFixtures = [JR_SEN_DISTRICT, SR_SEN_DISTRICT, REP_DISTRICT];
+const districtsById = new Map(districtsFixtures.map(dist => [dist.districtId, dist]))
 
 function getStore(isAdmin) {
     return mockStore({
@@ -164,45 +172,31 @@ const returnsDistrictCallers = (district) => {
     }
 }
 
-const CALLER_HISTORY = {
-    history: {
-        signUpHistory: [{
-            timestamp: 1,
-            timestampDisplay: "1/1/1",
-            type: "Sign Up"
-        }],
-        callHistory: [{
-            timestamp: 6,
-            timestampDisplay: "1/1/6",
-            type: "Called"
-        },
-        {
-            timestamp: 3,
-            timestampDisplay: "1/1/3",
-            type: "Called"
-        }],
-        reminderHistory: [{
-            timestamp: 4,
-            timestampDisplay: "1/1/4",
-            type: "Sent Reminder"
-        },
-        {
-            timestamp: 5,
-            timestampDisplay: "1/1/5",
-            type: "Sent Reminder"
-        }, {
-            timestamp: 7,
-            timestampDisplay: "1/1/7",
-            type: "Sent Reminder"
-        }]
+const CALLER_HISTORY = [
+    {
+        timestamp: 15,
+        timestampDisplay: '1/15/2020',
+        type: 'Call',
+        districtId: 2
+    },
+    {
+        timestamp: 10,
+        timestampDisplay: '1/10/2020',
+        type: 'Call',
+        districtId: 321
+    },
+    {
+        timestamp: 5,
+        timestampDisplay: '1/5/2020',
+        type: 'Notification',
+        url: 'http://www.cclcalls.org?t=qwer'
+    },
+    {
+        timestamp: 1,
+        timestampDisplay: '1/1/2020',
+        type: 'Sign Up'
     }
-}
-
-const returnsCallerHistory = () => {
-    return {
-        history: CALLER_HISTORY
-    }
-}
+]
 
 describe("Callers.js Unit Test", () => {
     test("Tests Super Admin", () => {
@@ -296,5 +290,21 @@ describe("Callers.js Unit Test", () => {
             </Provider>
         );
         expect(Redirect).toHaveBeenCalledTimes(2);
+    })
+
+    test("Displays caller history", () => {
+        const { getAllByText, getAllByDisplayValue } = render(
+            <HistoryPanel history={CALLER_HISTORY} caller={CALLER_CURRENT_REP} districtsById={districtsById} />
+        )
+        const texts = [
+            'Sign Up on 1/1/2020',
+            'Notification on 1/5/2020',
+            'Call to unknown district on 1/10/2020',
+            'Call to Neysa Sheen (MI-1) on 1/15/2020'
+        ]
+        texts.forEach((el) => {
+            expect(getAllByText(el)).toHaveLength(1)
+        })
+        expect(getAllByDisplayValue('http://www.cclcalls.org?t=qwer')).toHaveLength(1)
     })
 })

--- a/src/containers/Callers/HistoryPanel.js
+++ b/src/containers/Callers/HistoryPanel.js
@@ -15,6 +15,7 @@ import {
 import { authHeader } from '../../_util/auth/auth-header';
 import { HistoryType } from './constants'
 import axios from '../../_util/axios-api';
+import { displayName } from '../../_util/district';
 
 const sendNotification = (callerId) => {
     const requestOptions = {
@@ -32,6 +33,7 @@ const sendNotification = (callerId) => {
 const HistoryPanel = ({
     history,
     caller,
+    districtsById
 }) => { 
     const events = history.map((item, idx)=> {
         // TODO: Possibly use an icon here, or expand on the colors
@@ -43,6 +45,16 @@ const HistoryPanel = ({
             color = 'gray'
         } else if (item.type === HistoryType.SIGN_UP) {
             color = 'blue'
+        }
+
+        let description = item.type
+        if (item.type === HistoryType.CALL) {
+            if (districtsById.has(item.districtId)) {
+                const district = districtsById.get(item.districtId)
+                description += ` to ${district.repFirstName} ${district.repLastName} (${displayName(district)})`
+            } else {
+                description += ' to unknown district'
+            }
         }
 
         let url
@@ -65,8 +77,8 @@ const HistoryPanel = ({
         return  (
             <Timeline.Item key={idx} color={color}>
                 <Row>
-                    <Col span={10}>{item.type} on {item.timestampDisplay}</Col>
-                    <Col span={14}>{url}</Col>
+                    <Col span={url ? 10 : 24}>{description} on {item.timestampDisplay}</Col>
+                    {url && <Col span={14}>{url}</Col>}
                 </Row>
             </Timeline.Item>
         )


### PR DESCRIPTION
A couple notes about this code:

1. The call recipient name is displayed based on current district data. This will change after the election. Calls to previous reps in 2019 and 2020 will be displayed as if they were made to the current (2021) rep.

2. The CSV download of call history now includes the district ID buried in JSON. Would it be helpful to include the rep name in this JSON as well?