### PR TITLE
Call history recipient, refactored

### DIFF
--- a/src/_util/axios-api.js
+++ b/src/_util/axios-api.js
@@ -98,9 +98,14 @@ function getCallerHistory(caller, districtsById) {
     const signUpHistory = [
       createHistoryItem({timestamp: caller.created, type: HistoryType.SIGN_UP}),
     ];
-    const callHistory = _.map(calls.data, ({ created, districtId }) =>
-      createHistoryItem({timestamp: created, type: HistoryType.CALL, districtId})
-    );
+    const callHistory = _.map(calls.data, ({ created, districtId }) => {
+      let recipient;
+      const district = districtsById.get(districtId);
+      if (district) {
+        recipient = `${district.repFirstName} ${district.repLastName} (${displayName(district)})`;
+      }
+      return createHistoryItem({timestamp: created, type: HistoryType.CALL, recipient})
+    });
     const reminderHistory = _.map(reminders.data, ({ timeSent, targetDistrictId, trackingId }) => {
       const district = districtsById.get(targetDistrictId);
       const urlPath = `http://www.cclcalls.org/call/${district.state.toLowerCase()}/${district.number}`;

--- a/src/_util/axios-api.test.js
+++ b/src/_util/axios-api.test.js
@@ -56,6 +56,8 @@ describe('callerHistory', () => {
                 expect(stephenHistory.reminderHistory[1].url)
                     .toBe('http://www.cclcalls.org/call/aa/2?t=RZnaDi0q&c=452&d=3');
                 expect(stephenHistory.callHistory.length).toBe(1);
+                expect(stephenHistory.callHistory[0].recipient)
+                  .toBe('AA3FirstName AA3LastName (AA-3)');
                 expect(haranHistory.reminderHistory.length).toBe(1);
                 done();
             });

--- a/src/containers/Callers/CallerDetailModal.js
+++ b/src/containers/Callers/CallerDetailModal.js
@@ -33,7 +33,7 @@ class CallerDetailModal extends Component {
         const caller = this.props.caller && this.props.caller.caller;
         return (
             <Skeleton active loading={!history || !caller}>
-                <HistoryPanel history={history} caller={caller} districtsById={this.props.districtsById} />
+                <HistoryPanel history={history} caller={caller} />
             </Skeleton>
         )
     }

--- a/src/containers/Callers/Callers.js
+++ b/src/containers/Callers/Callers.js
@@ -303,7 +303,6 @@ class Callers extends Component {
       <CallerDetailModal
         caller={this.state.callerDetail}
         display={caller != null}
-        districtsById={this.props.districtsById}
         onEditCaller={(callerDetails) => {
           this.onEditCaller(callerDetails);
         }}

--- a/src/containers/Callers/Callers.test.js
+++ b/src/containers/Callers/Callers.test.js
@@ -49,7 +49,6 @@ const REP_DISTRICT = {
 };
 
 const districtsFixtures = [JR_SEN_DISTRICT, SR_SEN_DISTRICT, REP_DISTRICT];
-const districtsById = new Map(districtsFixtures.map(dist => [dist.districtId, dist]))
 
 function getStore(isAdmin) {
     return mockStore({
@@ -177,13 +176,12 @@ const CALLER_HISTORY = [
         timestamp: 15,
         timestampDisplay: '1/15/2020',
         type: 'Call',
-        districtId: 2
     },
     {
         timestamp: 10,
         timestampDisplay: '1/10/2020',
         type: 'Call',
-        districtId: 321
+        recipient: 'Xerbi Qaraq (MI-Sen. Senator)'
     },
     {
         timestamp: 5,
@@ -294,13 +292,13 @@ describe("Callers.js Unit Test", () => {
 
     test("Displays caller history", () => {
         const { getAllByText, getAllByDisplayValue } = render(
-            <HistoryPanel history={CALLER_HISTORY} caller={CALLER_CURRENT_REP} districtsById={districtsById} />
+            <HistoryPanel history={CALLER_HISTORY} caller={CALLER_CURRENT_REP} />
         )
         const texts = [
             'Sign Up on 1/1/2020',
             'Notification on 1/5/2020',
-            'Call to unknown district on 1/10/2020',
-            'Call to Neysa Sheen (MI-1) on 1/15/2020'
+            'Call to Xerbi Qaraq (MI-Sen. Senator) on 1/10/2020',
+            'Call on 1/15/2020'
         ]
         texts.forEach((el) => {
             expect(getAllByText(el)).toHaveLength(1)

--- a/src/containers/Callers/HistoryPanel.js
+++ b/src/containers/Callers/HistoryPanel.js
@@ -15,7 +15,6 @@ import {
 import { authHeader } from '../../_util/auth/auth-header';
 import { HistoryType } from './constants'
 import axios from '../../_util/axios-api';
-import { displayName } from '../../_util/district';
 
 const sendNotification = (callerId) => {
     const requestOptions = {
@@ -33,7 +32,6 @@ const sendNotification = (callerId) => {
 const HistoryPanel = ({
     history,
     caller,
-    districtsById
 }) => { 
     const events = history.map((item, idx)=> {
         // TODO: Possibly use an icon here, or expand on the colors
@@ -45,16 +43,6 @@ const HistoryPanel = ({
             color = 'gray'
         } else if (item.type === HistoryType.SIGN_UP) {
             color = 'blue'
-        }
-
-        let description = item.type
-        if (item.type === HistoryType.CALL) {
-            if (districtsById.has(item.districtId)) {
-                const district = districtsById.get(item.districtId)
-                description += ` to ${district.repFirstName} ${district.repLastName} (${displayName(district)})`
-            } else {
-                description += ' to unknown district'
-            }
         }
 
         let url
@@ -77,7 +65,9 @@ const HistoryPanel = ({
         return  (
             <Timeline.Item key={idx} color={color}>
                 <Row>
-                    <Col span={url ? 10 : 24}>{description} on {item.timestampDisplay}</Col>
+                    <Col span={url ? 10 : 24}>
+                        {item.type}{item.recipient && ' to ' + item.recipient} on {item.timestampDisplay}
+                    </Col>
                     {url && <Col span={14}>{url}</Col>}
                 </Row>
             </Timeline.Item>


### PR DESCRIPTION
After more thought, I came up with a different way to manage the call recipient.  This undoes some of yesterday's work but achieves the same effect in a better way.

Computing the rep name in axios-api instead of during rendering
simplifies the logic and makes the rep name show up in the JSON inside
the CSV file.