### PR TITLE
Talking Point Moderation

### DIFF
--- a/src/_util/axios-api.js
+++ b/src/_util/axios-api.js
@@ -36,6 +36,28 @@ export function updateRequest(district, request) {
   return client(requestOptions)
 }
 
+export function addTalkingPoint(newTalkingPoint) {
+  const requestOptions = makeRequestOptions('/talkingpoints', 'POST')
+  requestOptions['data'] = newTalkingPoint
+  return client(requestOptions)
+}
+
+export function editTalkingPoint(talkingPoint) {
+  const requestOptions = makeRequestOptions(`/talkingpoints/${talkingPoint.talkingPointId}`, 'PUT')
+  requestOptions['data'] = talkingPoint
+  return client(requestOptions)
+}
+
+export function getAdmins() {
+  const requestOptions = makeRequestOptions('/admins')
+  return client(requestOptions)
+}
+
+export function getTalkingPoints() {
+  const requestOptions = makeRequestOptions('/talkingpoints')
+  return client(requestOptions)
+}
+
 export function updateScript(district, talkingPointIds) {
   const requestOptions = makeRequestOptions(`/districts/${district.districtId}/script`, "PUT")
   requestOptions['data'] = talkingPointIds
@@ -58,6 +80,11 @@ export function getThemes() {
 
 export function getHydratedDistict(district) {  
   const requestOptions = makeRequestOptions(`/districts/${district.districtId}/hydrated`)
+  return client(requestOptions)
+}
+
+export function getScript(district) {
+  const requestOptions = makeRequestOptions(`/districts/${district.districtId}/script`)
   return client(requestOptions)
 }
 

--- a/src/containers/TalkingPoints/TalkingPointCard.js
+++ b/src/containers/TalkingPoints/TalkingPointCard.js
@@ -1,11 +1,11 @@
 import React from "react";
 import { Icon, List, Typography } from 'antd';
+import TalkingPointModerationForm from './TalkingPointModerationForm'
 
-const TalkingPointCard = ({talkingPoint, createdBy, theme, isInScript, scriptToggle, edit, isShowingModerationControls }) => {
+const TalkingPointCard = ({talkingPoint, createdBy, theme, isInScript, scriptToggle, edit, isShowingModerationControl, updateApproval }) => {
         if (talkingPoint == null || talkingPoint.created == null) {
             return null
         }
-
         const reference = talkingPoint.referenceUrl ?
             <Typography.Text copyable={{ text: talkingPoint.referenceUrl }}>
                 <a target="_blank" href={talkingPoint.referenceUrl} rel="noopener noreferrer">Reference URL</a>
@@ -16,30 +16,47 @@ const TalkingPointCard = ({talkingPoint, createdBy, theme, isInScript, scriptTog
              : null;
         const description = createdByDesc
 
+        const actions = [
+            <span>
+                <Icon style={{ marginRight: 8, color: "#0081C7" }} type={isInScript ? "check-square" : "border"} onClick={(e)=> {
+                   scriptToggle(talkingPoint.talkingPointId)
+                } }/>
+                <Typography.Text>In Script</Typography.Text>
+            </span>,
+            <span>
+                <Icon style={{ marginRight: 8 }} type="edit" theme="twoTone" twoToneColor="#0081C7" onClick={(e)=> {
+                    edit(talkingPoint)
+                } } />
+                <Typography.Text>Edit</Typography.Text>
+            </span> 
+        ]
+
+
+
+        const moderationSection = isShowingModerationControl ? (
+            <TalkingPointModerationForm
+                talkingPoint = {talkingPoint}
+                onValuesChange = {(props, _, values) => {
+                    const tp = {...talkingPoint}
+                    tp.reviewStatus = props.status
+                    updateApproval(tp)
+                }}
+            />
+            
+        ) : null
+
         return <List.Item
             style={{background: talkingPoint.bg, padding: "10px"}}
             key={talkingPoint.talkingPointId}
             extra={reference}
-            actions={[
-                <span>
-                    <Icon style={{ marginRight: 8, color: "#0081C7" }} type={isInScript ? "check-square" : "border"} onClick={(e)=> {
-                       scriptToggle(talkingPoint.talkingPointId)
-                    } }/>
-                    <Typography.Text>In Script</Typography.Text>
-                </span>,
-                <span>
-                    <Icon style={{ marginRight: 8 }} type="edit" theme="twoTone" twoToneColor="#0081C7" onClick={(e)=> {
-                        edit(talkingPoint)
-                    } } />
-                    <Typography.Text>Edit</Typography.Text>
-                </span> 
-            ]}
+            actions={actions}
         >
             <List.Item.Meta
                 title={theme.name}
                 description= {description}
             />
                 <Typography.Paragraph>{talkingPoint.content}</Typography.Paragraph>
+                {moderationSection}
         </List.Item>  
 };
 

--- a/src/containers/TalkingPoints/TalkingPointCard.js
+++ b/src/containers/TalkingPoints/TalkingPointCard.js
@@ -43,6 +43,7 @@ const TalkingPointCard = ({talkingPoint, createdBy, theme, isInScript, scriptTog
 
         const moderationSection = isShowingModerationControl ? (
             <div>
+                <Typography.Title level={4}>Moderation</Typography.Title>
                 <Typography.Paragraph>Talking Point Id: {`${talkingPoint.talkingPointId}`}</Typography.Paragraph>
                 <Typography.Paragraph>Scope: {scopeDescription}</Typography.Paragraph>
                 <TalkingPointModerationForm

--- a/src/containers/TalkingPoints/TalkingPointCard.js
+++ b/src/containers/TalkingPoints/TalkingPointCard.js
@@ -1,0 +1,46 @@
+import React from "react";
+import { Icon, List, Typography } from 'antd';
+
+const TalkingPointCard = ({talkingPoint, createdBy, theme, isInScript, scriptToggle, edit}) => {
+        if (talkingPoint == null || talkingPoint.created == null) {
+            return null
+        }
+
+        const reference = talkingPoint.referenceUrl ?
+            <Typography.Text copyable={{ text: talkingPoint.referenceUrl }}>
+                <a target="_blank" href={talkingPoint.referenceUrl} rel="noopener noreferrer">Reference URL</a>
+            </Typography.Text> : null;
+        const createdDate = new Date(talkingPoint.created.replace(/-/g, "/") + " UTC");
+        const createdByDesc = createdBy && createdBy.email ?
+        <><Typography.Text style={{fontStyle: "italic"}}>Created on {createdDate.toDateString()} by: </Typography.Text><Typography.Text style={{fontStyle: "italic", color: "#0081C7"}} copyable={{ text: createdBy.email }}>{createdBy.email} </Typography.Text></>
+             : null;
+        const description = createdByDesc
+
+        return <List.Item
+            style={{background: talkingPoint.bg, padding: "10px"}}
+            key={talkingPoint.talkingPointId}
+            extra={reference}
+            actions={[
+                <span>
+                    <Icon style={{ marginRight: 8, color: "#0081C7" }} type={isInScript ? "check-square" : "border"} onClick={(e)=> {
+                       scriptToggle(talkingPoint.talkingPointId)
+                    } }/>
+                    <Typography.Text>In Script</Typography.Text>
+                </span>,
+                <span>
+                    <Icon style={{ marginRight: 8 }} type="edit" theme="twoTone" twoToneColor="#0081C7" onClick={(e)=> {
+                        edit(talkingPoint)
+                    } } />
+                    <Typography.Text>Edit</Typography.Text>
+                </span> 
+            ]}
+        >
+            <List.Item.Meta
+                title={theme.name}
+                description= {description}
+            />
+                <Typography.Paragraph>{talkingPoint.content}</Typography.Paragraph>
+        </List.Item>  
+};
+
+export default TalkingPointCard;

--- a/src/containers/TalkingPoints/TalkingPointCard.js
+++ b/src/containers/TalkingPoints/TalkingPointCard.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Icon, List, Typography } from 'antd';
 import TalkingPointModerationForm from './TalkingPointModerationForm'
 
-const TalkingPointCard = ({talkingPoint, createdBy, theme, isInScript, scriptToggle, edit, isShowingModerationControl, updateApproval }) => {
+const TalkingPointCard = ({talkingPoint, createdBy, theme, isInScript, scriptToggle, edit, isShowingModerationControl, updateApproval, districtsById }) => {
         if (talkingPoint == null || talkingPoint.created == null) {
             return null
         }
@@ -31,17 +31,29 @@ const TalkingPointCard = ({talkingPoint, createdBy, theme, isInScript, scriptTog
             </span> 
         ]
 
+        var scopeDescription = talkingPoint.scope
+
+        if (talkingPoint.scope === 'state') {
+            scopeDescription += `s: ${talkingPoint.states.join(', ')}`
+        } else if (talkingPoint.scope === 'district') {
+            const districts = talkingPoint.districts.map((el) => { return `${districtsById.get(el).state} - ${districtsById.get(el).number}` }).join(', ')
+            scopeDescription += `s: ${districts}`
+        }
 
 
         const moderationSection = isShowingModerationControl ? (
-            <TalkingPointModerationForm
-                talkingPoint = {talkingPoint}
-                onValuesChange = {(props, _, values) => {
-                    const tp = {...talkingPoint}
-                    tp.reviewStatus = props.status
-                    updateApproval(tp)
-                }}
-            />
+            <div>
+                <Typography.Paragraph>Talking Point Id: {`${talkingPoint.talkingPointId}`}</Typography.Paragraph>
+                <Typography.Paragraph>Scope: {scopeDescription}</Typography.Paragraph>
+                <TalkingPointModerationForm
+                    talkingPoint = {talkingPoint}
+                    onValuesChange = {(props, _, values) => {
+                        const tp = {...talkingPoint}
+                        tp.reviewStatus = props.status
+                        updateApproval(tp)
+                    }}
+                />
+            </div>
             
         ) : null
 

--- a/src/containers/TalkingPoints/TalkingPointCard.js
+++ b/src/containers/TalkingPoints/TalkingPointCard.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Icon, List, Typography } from 'antd';
 
-const TalkingPointCard = ({talkingPoint, createdBy, theme, isInScript, scriptToggle, edit}) => {
+const TalkingPointCard = ({talkingPoint, createdBy, theme, isInScript, scriptToggle, edit, isShowingModerationControls }) => {
         if (talkingPoint == null || talkingPoint.created == null) {
             return null
         }

--- a/src/containers/TalkingPoints/TalkingPointModerationForm.js
+++ b/src/containers/TalkingPoints/TalkingPointModerationForm.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Form, Select, Typography } from "antd";
+import { Form, Select } from "antd";
 
 class TalkingPointModeration extends Component {
   render() {
@@ -10,7 +10,6 @@ class TalkingPointModeration extends Component {
     const { getFieldDecorator } = this.props.form;
     return (
       <div>
-        <Typography.Title level={4}>Moderation</Typography.Title>
         <Form>
           <Form.Item label="Status">
             {getFieldDecorator("status", {

--- a/src/containers/TalkingPoints/TalkingPointModerationForm.js
+++ b/src/containers/TalkingPoints/TalkingPointModerationForm.js
@@ -1,0 +1,46 @@
+import React, { Component } from "react";
+import { Form, Select, Typography } from "antd";
+
+class TalkingPointModeration extends Component {
+  render() {
+    const talkingPoint = this.props.talkingPoint
+    if (this.props.talkingPoint == null) {
+      return null;
+    }
+    const { getFieldDecorator } = this.props.form;
+    return (
+      <div>
+        <Typography.Title level={4}>Moderation</Typography.Title>
+        <Form>
+          <Form.Item label="Status">
+            {getFieldDecorator("status", {
+              initialValue: talkingPoint.reviewStatus,
+            })(
+              <Select>
+                <Select.Option key="promoted" value="promoted">
+                  Promote
+                </Select.Option>
+                <Select.Option key="passed" value="passed">
+                  Suppress
+                </Select.Option>
+                <Select.Option key="archived" value="archived">
+                  Archive
+                </Select.Option>
+                <Select.Option value="waiting_review" disabled>
+                  Awaiting Review
+                </Select.Option>
+              </Select>
+            )}
+          </Form.Item>
+        </Form>
+      </div>
+    );
+  }
+}
+
+const TalkingPointModerationForm = Form.create({
+  name: "talking_points_moderation",
+  onValuesChange: (props, _, values) => props.onValuesChange(values),
+})(TalkingPointModeration);
+
+export default TalkingPointModerationForm;

--- a/src/containers/TalkingPoints/TalkingPoints.js
+++ b/src/containers/TalkingPoints/TalkingPoints.js
@@ -2,13 +2,14 @@ import React, { Component } from 'react';
 import { Redirect } from 'react-router-dom';
 import moment from 'moment';
 import { connect } from 'react-redux';
-import { Button, Icon, Input, List, message, Modal, Skeleton, Spin, Typography } from 'antd';
+import { Button, Input, List, message, Modal, Skeleton, Spin, Typography } from 'antd';
 import get from "lodash/get"
 
 import { getTalkingPoints, getThemes, getAdmins, getScript, addTalkingPoint, editTalkingPoint, updateScript } from '../../_util/axios-api';
 import { slug as districtSlug } from "../../_util/district";
 import AddEditTalkingPointModal from './AddEditTalkingPointModal'
 import TalkingPointsFilterForm from './TalkingPointsFilterForm'
+import TalkingPointCard from './TalkingPointCard'
 
 import './TalkingPoints.module.css';
 
@@ -398,49 +399,20 @@ class TalkingPoints extends Component {
             // }}
         header={<Typography.Title level={3}>Search Results</Typography.Title>}
             dataSource={this.presentableTalkingPoints()}
-            renderItem={item => {
+            renderItem={talkingPoint => {
                 const theme = this.state.themes.find((el) => {
-                    return el.themeId === item.themeId
+                    return el.themeId === talkingPoint.themeId
                 });
-                const createdBy = item.createdBy && this.state.adminsById.get(item.createdBy);
-
-                const reference = item.referenceUrl ?
-                    <Typography.Text copyable={{ text: item.referenceUrl }}>
-                        <a target="_blank" href={item.referenceUrl} rel="noopener noreferrer">Reference URL</a>
-                    </Typography.Text> : null;
-
-                const createdDate = new Date(item.created.replace(/-/g, "/") + " UTC");
-                const createdByDesc = createdBy && createdBy.email ?
-                <><Typography.Text style={{fontStyle: "italic"}}>Created on {createdDate.toDateString()} by: </Typography.Text><Typography.Text style={{fontStyle: "italic", color: "#0081C7"}} copyable={{ text: createdBy.email }}>{createdBy.email} </Typography.Text></>
-                     : null;
-                const description = createdByDesc
-
-                const isInScript = this.state.liveTalkingPoints.includes(item.talkingPointId)
-                return <List.Item
-                    style={{background: item.bg, padding: "10px"}}
-                    key={item.talkingPointId}
-                    extra={reference}
-                    actions={[
-                        <span>
-                            <Icon style={{ marginRight: 8, color: "#0081C7" }} type={isInScript ? "check-square" : "border"} onClick={(e)=> {
-                                this.toggleTalkingPointInclusionInScript(item.talkingPointId)
-                            } }/>
-                            <Typography.Text>In Script</Typography.Text>
-                        </span>,
-                        <span>
-                            <Icon style={{ marginRight: 8 }} type="edit" theme="twoTone" twoToneColor="#0081C7" onClick={(e)=> {
-                                this.initiateEditTalkingPoint(item)
-                            } } />
-                            <Typography.Text>Edit</Typography.Text>
-                        </span> 
-                    ]}
-                >
-                    <List.Item.Meta
-                        title={theme.name}
-                        description= {description}
-                    />
-                        <Typography.Paragraph>{item.content}</Typography.Paragraph>
-                </List.Item>
+                const createdBy = talkingPoint.createdBy && this.state.adminsById.get(talkingPoint.createdBy)
+                const isInScript = this.state.liveTalkingPoints.includes(talkingPoint.talkingPointId)
+                return <TalkingPointCard 
+                    talkingPoint = {talkingPoint}
+                    createdBy = {createdBy}
+                    theme = { theme }
+                    isInScript = { isInScript }
+                    scriptToggle = { this.toggleTalkingPointInclusionInScript }
+                    edit = { this.initiateEditTalkingPoint }
+                />                
                 }
             }
         />

--- a/src/containers/TalkingPoints/TalkingPoints.js
+++ b/src/containers/TalkingPoints/TalkingPoints.js
@@ -25,10 +25,10 @@ class TalkingPoints extends Component {
         liveTalkingPoints: null,
         redirect: null,
         editing: null,
-        wantsToAddNewTalkingPoint: false,
+        isAddingNewTalkingPoint: false,
         admins: null,
         adminsById: null,
-        editingTalkingPointDetails: null
+        isEditingTalkingPointsDetails: null
     }
 
     componentDidMount() {
@@ -193,12 +193,12 @@ class TalkingPoints extends Component {
 
     addNewTalkingPointClicked = () => {
         this.setState({
-            wantsToAddNewTalkingPoint: true
+            isAddingNewTalkingPoint: true
         })
     }
 
     handleSaveTalkingPoint = (values) => {
-        this.setState({wantsToAddNewTalkingPoint: false, editingTalkingPointDetails: null, editing: true})
+        this.setState({isAddingNewTalkingPoint: false, isEditingTalkingPointsDetails: null, editing: true})
 
         const body = {
             content: values.content,
@@ -254,18 +254,18 @@ class TalkingPoints extends Component {
     }
 
     handleCancelAddNewTalkingPoint = () => {
-        this.setState({wantsToAddNewTalkingPoint: false, editingTalkingPointDetails: null})
+        this.setState({isAddingNewTalkingPoint: false, isEditingTalkingPointsDetails: null})
     }
 
     addEditTalkingPointModal = () => {
         return this.hasTalkingPoints() ?
             <AddEditTalkingPointModal
                 themes={this.state.themes}
-                display={this.state.wantsToAddNewTalkingPoint || this.state.editingTalkingPointDetails !== null}
+                display={this.state.isAddingNewTalkingPoint || this.state.isEditingTalkingPointsDetails !== null}
                 handleSave={(vals)=>{this.handleSaveTalkingPoint(vals)}}
                 handleCancel={this.handleCancelAddNewTalkingPoint}
                 districts={this.props.districts}
-                talkingPointUnderEdit={this.state.editingTalkingPointDetails}
+                talkingPointUnderEdit={this.state.isEditingTalkingPointsDetails}
             /> : null;
     }
 
@@ -311,7 +311,7 @@ class TalkingPoints extends Component {
                 style={{position: "absolute", right: "10px", top:"10px"}}
                 type="primary"
                 onClick={this.addNewTalkingPointClicked || !this.hasTalkingPoints()}
-                disabled={this.state.wantsToAddNewTalkingPoint}>
+                disabled={this.state.isAddingNewTalkingPoint}>
                     Add A New Talking Point
             </Button>
         </div>);
@@ -342,7 +342,7 @@ class TalkingPoints extends Component {
         }
 
         this.setState({
-            editingTalkingPointDetails: talkingPointDetails
+            isEditingTalkingPointsDetails: talkingPointDetails
         })
     }
 

--- a/src/containers/TalkingPoints/TalkingPoints.js
+++ b/src/containers/TalkingPoints/TalkingPoints.js
@@ -241,6 +241,9 @@ class TalkingPoints extends Component {
     }
 
     editExistingTalkingPoint = (talkingPoint) => {
+        delete talkingPoint['created']
+        delete talkingPoint['lastModified']
+        delete talkingPoint['bg']
         editTalkingPoint(talkingPoint).then((response)=>{
             message.success('Talking Point Edited');
         }).catch((e) => {
@@ -412,7 +415,8 @@ class TalkingPoints extends Component {
                     isInScript = { isInScript }
                     scriptToggle = { this.toggleTalkingPointInclusionInScript }
                     edit = { this.initiateEditTalkingPoint }
-                    isShowingModerationControls = { this.props.admin.root }
+                    isShowingModerationControl = { this.props.admin.root }
+                    updateApproval = {this.editExistingTalkingPoint}
                 />                
                 }
             }

--- a/src/containers/TalkingPoints/TalkingPoints.js
+++ b/src/containers/TalkingPoints/TalkingPoints.js
@@ -2,94 +2,16 @@ import React, { Component } from 'react';
 import { Redirect } from 'react-router-dom';
 import moment from 'moment';
 import { connect } from 'react-redux';
-import { Button, Checkbox, Col, Form, Icon, Input, List, message, Modal, DatePicker, Row, Select, Skeleton, Spin, Typography } from 'antd';
+import { Button, Icon, Input, List, message, Modal, Skeleton, Spin, Typography } from 'antd';
 import get from "lodash/get"
 
 import axios from '../../_util/axios-api';
 import { authHeader } from '../../_util/auth/auth-header';
 import { slug as districtSlug } from "../../_util/district";
 import AddEditTalkingPointModal from './AddEditTalkingPointModal'
+import TalkingPointsFilterForm from './TalkingPointsFilterForm'
 
 import './TalkingPoints.module.css';
-
-class TalkingPointsFilter extends Component {
-
-    render() {
-        const filters = this.props.filters;
-        const { getFieldDecorator } = this.props.form;
-        return (
-            <Form>
-                <Row>
-                    <Col sm={24} md={12} >
-                        <Form.Item label="Creation Date">
-                            {getFieldDecorator("creationDate", {initialValue: filters && filters.creationDate})(
-                                <DatePicker.RangePicker />
-                            )}
-                        </Form.Item>
-                    </Col>
-                    <Col sm={24} md={12} >
-                        <Form.Item label="Last Updated Date">
-                            {getFieldDecorator("updatedDate", {initialValue: filters && filters.updatedDate})(
-                                <DatePicker.RangePicker />
-                            )}
-                        </Form.Item>
-                    </Col>
-                </Row>
-                <Row gutter={[{ xs: 8, sm: 16, md: 24, lg: 32 }, 20]}>
-                    <Col sm={24} md={6} >
-                        <Form.Item label="Relevance">
-                            {getFieldDecorator("scope", {initialValue: filters && filters.scope})(
-                                <Checkbox.Group>
-                                    <Checkbox value={"national"}>National</Checkbox>
-                                    <Checkbox value={"state"}>My State</Checkbox>
-                                    <Checkbox value={"district"}>My District</Checkbox>
-                            </Checkbox.Group>
-                            )}
-                        </Form.Item>
-                    </Col>
-                    <Col sm={24} md={6} >
-                        <Form.Item label="Theme">
-                        {getFieldDecorator("theme", {initialValue: filters && filters.theme})(
-                            <Select
-                                showSearch
-                                allowClear
-                                placeholder="Select a theme"
-                                optionFilterProp="children"
-                                filterOption={(input, option) => option.props.children.toLowerCase().indexOf(input.toLowerCase()) >= 0}>
-                                {this.props.themes.map((el)=>{
-                                    return (<Select.Option key={el.name} value={el.name}>{el.name}</Select.Option>)
-                                })}
-                            </Select>,
-                            )}
-                        </Form.Item>
-                    </Col>
-                    <Col sm={24} md={6} >
-                        <Form.Item label="Currently selected">
-                            {getFieldDecorator("script", {
-                                valuePropName: 'checked',
-                                initialValue: filters && filters.script
-                            })(
-                                <Checkbox value={"script"}>In Script</Checkbox>
-                            )}
-                        </Form.Item>
-                    </Col>
-                    <Col sm={24} md={6} >
-                        <Form.Item label="Author">
-                            {getFieldDecorator("author", {initialValue: filters && filters.author})(
-                                <Input placeholder="Username or email" />
-                            )}
-                        </Form.Item>
-                    </Col>
-                </Row>
-            </Form>
-        );
-    }
-}
-
-const TalkingPointsFilterForm = Form.create({
-    name: 'talking_points_filter_sort',
-    onValuesChange: (props, _, values) => props.onValuesChange(values)
-})(TalkingPointsFilter);
 
 class TalkingPoints extends Component {
 

--- a/src/containers/TalkingPoints/TalkingPoints.js
+++ b/src/containers/TalkingPoints/TalkingPoints.js
@@ -99,7 +99,16 @@ class TalkingPoints extends Component {
         }
 
         const filters = this.state.filters;
-        const presentableTalkingPoints = [...this.state.allTalkingPoints].filter(el =>{
+        const presentableTalkingPoints = [...this.state.allTalkingPoints]
+        .filter(el => {
+            if (this.props.admin.root) {
+                return filters.reviewStatus === undefined || filters.reviewStatus.length === 0 ||
+                filters.reviewStatus.indexOf(el.reviewStatus) !== -1
+            } else {
+                return el.createdBy === this.props.admin.adminId || el.reviewStatus === 'promoted' || el.reviewStatus === 'waiting_review' // remove the waiting review option once all TPs have been reviewed
+            }
+        })
+        .filter(el =>{
             if (filters && filters.creationDate && filters.creationDate.length > 0) {
                 const creationDateRange = this.state.filters.creationDate;
                 const start = creationDateRange[0];
@@ -331,7 +340,9 @@ class TalkingPoints extends Component {
                 <TalkingPointsFilterForm
                     themes={this.state.themes}
                     filters={this.state.filters}
-                    onValuesChange={this.handleFilterChange} />
+                    onValuesChange={this.handleFilterChange} 
+                    showsModerationControl = {this.props.admin.root}
+                    />
             </div>
         );
     }
@@ -417,6 +428,7 @@ class TalkingPoints extends Component {
                     edit = { this.initiateEditTalkingPoint }
                     isShowingModerationControl = { this.props.admin.root }
                     updateApproval = {this.editExistingTalkingPoint}
+                    districtsById = {this.props.districtsById}
                 />                
                 }
             }
@@ -440,7 +452,8 @@ const mapStateToProps = state => {
 
     return {
         admin: {...admin.admin},
-        districts: state.districts.districts
+        districts: state.districts.districts,
+        districtsById: state.districts.districtsById
     };
 };
 

--- a/src/containers/TalkingPoints/TalkingPoints.js
+++ b/src/containers/TalkingPoints/TalkingPoints.js
@@ -366,7 +366,7 @@ class TalkingPoints extends Component {
     }
 
     initiateEditTalkingPoint = (talkingPointDetails) => {
-        if (this.props.adminId && this.props.adminId !== talkingPointDetails.createdBy) {
+        if (this.props.admin.adminId && this.props.admin.adminId !== talkingPointDetails.createdBy) {
             Modal.error({
                 title: 'Not Allowed to Edit',
                 content: "Only the person who created this talking point can edit it."
@@ -499,10 +499,9 @@ class TalkingPoints extends Component {
 const mapStateToProps = state => {
 
     const admin = {...state.admin}
-    const adminTwo = {...admin.admin}
 
     return {
-        adminId: adminTwo.adminId,
+        admin: {...admin.admin},
         districts: state.districts.districts
     };
 };

--- a/src/containers/TalkingPoints/TalkingPoints.js
+++ b/src/containers/TalkingPoints/TalkingPoints.js
@@ -412,6 +412,7 @@ class TalkingPoints extends Component {
                     isInScript = { isInScript }
                     scriptToggle = { this.toggleTalkingPointInclusionInScript }
                     edit = { this.initiateEditTalkingPoint }
+                    isShowingModerationControls = { this.props.admin.root }
                 />                
                 }
             }

--- a/src/containers/TalkingPoints/TalkingPointsFilterForm.js
+++ b/src/containers/TalkingPoints/TalkingPointsFilterForm.js
@@ -6,6 +6,24 @@ class TalkingPointsFilter extends Component {
     render() {
         const filters = this.props.filters;
         const { getFieldDecorator } = this.props.form;
+
+        const moderationControl = this.props.showsModerationControl ? (
+            <Row>
+                <Col>
+                    <Form.Item label="Review Status">
+                        {getFieldDecorator("reviewStatus", {initialValue: filters && filters.reviewStatus})(
+                            <Checkbox.Group>
+                                <Checkbox value={"promoted"}>Approved</Checkbox>
+                                <Checkbox value={"passed"}>Suppressed</Checkbox>
+                                <Checkbox value={"waiting_review"}>Awaiting Review</Checkbox>
+                                <Checkbox value={"archived"}>Archived</Checkbox>
+                            </Checkbox.Group>
+                        )}
+                    </Form.Item>
+                </Col>
+            </Row>
+        ) : null
+
         return (
             <Form>
                 <Row>
@@ -70,6 +88,7 @@ class TalkingPointsFilter extends Component {
                         </Form.Item>
                     </Col>
                 </Row>
+                {moderationControl}
             </Form>
         );
     }

--- a/src/containers/TalkingPoints/TalkingPointsFilterForm.js
+++ b/src/containers/TalkingPoints/TalkingPointsFilterForm.js
@@ -1,0 +1,83 @@
+import React, { Component } from 'react';
+import { Checkbox, Col, Form, Input, DatePicker, Row, Select } from 'antd';
+
+class TalkingPointsFilter extends Component {
+
+    render() {
+        const filters = this.props.filters;
+        const { getFieldDecorator } = this.props.form;
+        return (
+            <Form>
+                <Row>
+                    <Col sm={24} md={12} >
+                        <Form.Item label="Creation Date">
+                            {getFieldDecorator("creationDate", {initialValue: filters && filters.creationDate})(
+                                <DatePicker.RangePicker />
+                            )}
+                        </Form.Item>
+                    </Col>
+                    <Col sm={24} md={12} >
+                        <Form.Item label="Last Updated Date">
+                            {getFieldDecorator("updatedDate", {initialValue: filters && filters.updatedDate})(
+                                <DatePicker.RangePicker />
+                            )}
+                        </Form.Item>
+                    </Col>
+                </Row>
+                <Row gutter={[{ xs: 8, sm: 16, md: 24, lg: 32 }, 20]}>
+                    <Col sm={24} md={6} >
+                        <Form.Item label="Relevance">
+                            {getFieldDecorator("scope", {initialValue: filters && filters.scope})(
+                                <Checkbox.Group>
+                                    <Checkbox value={"national"}>National</Checkbox>
+                                    <Checkbox value={"state"}>My State</Checkbox>
+                                    <Checkbox value={"district"}>My District</Checkbox>
+                            </Checkbox.Group>
+                            )}
+                        </Form.Item>
+                    </Col>
+                    <Col sm={24} md={6} >
+                        <Form.Item label="Theme">
+                        {getFieldDecorator("theme", {initialValue: filters && filters.theme})(
+                            <Select
+                                showSearch
+                                allowClear
+                                placeholder="Select a theme"
+                                optionFilterProp="children"
+                                filterOption={(input, option) => option.props.children.toLowerCase().indexOf(input.toLowerCase()) >= 0}>
+                                {this.props.themes.map((el)=>{
+                                    return (<Select.Option key={el.name} value={el.name}>{el.name}</Select.Option>)
+                                })}
+                            </Select>,
+                            )}
+                        </Form.Item>
+                    </Col>
+                    <Col sm={24} md={6} >
+                        <Form.Item label="Currently selected">
+                            {getFieldDecorator("script", {
+                                valuePropName: 'checked',
+                                initialValue: filters && filters.script
+                            })(
+                                <Checkbox value={"script"}>In Script</Checkbox>
+                            )}
+                        </Form.Item>
+                    </Col>
+                    <Col sm={24} md={6} >
+                        <Form.Item label="Author">
+                            {getFieldDecorator("author", {initialValue: filters && filters.author})(
+                                <Input placeholder="Username or email" />
+                            )}
+                        </Form.Item>
+                    </Col>
+                </Row>
+            </Form>
+        );
+    }
+}
+
+const TalkingPointsFilterForm = Form.create({
+    name: 'talking_points_filter_sort',
+    onValuesChange: (props, _, values) => props.onValuesChange(values)
+})(TalkingPointsFilter);
+
+export default TalkingPointsFilterForm;


### PR DESCRIPTION
Enables super admins to mark approval status of talking points, which, in turn, is used as a filter for which talking points appear in the library.