### PR TITLE
Improve error reporting

### DIFF
--- a/src/_util/axios-api.js
+++ b/src/_util/axios-api.js
@@ -36,6 +36,10 @@ export function updateRequest(district, request) {
   return client(requestOptions)
 }
 
+export function getErrorMessage(e) {
+  return e.response && e.response.data ? e.response.data.message : e.message
+}
+
 export function addTalkingPoint(newTalkingPoint) {
   const requestOptions = makeRequestOptions('/talkingpoints', 'POST')
   requestOptions['data'] = newTalkingPoint

--- a/src/containers/CallDistribution/CallDistribution.js
+++ b/src/containers/CallDistribution/CallDistribution.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Redirect } from 'react-router-dom';
 import { Button, Col, InputNumber, Modal, Skeleton, Form, Row, Typography} from 'antd';
 
-import axios from '../../_util/axios-api';
+import axios, { getErrorMessage } from '../../_util/axios-api';
 import { authHeader } from '../../_util/auth/auth-header';
 
 import styles from './CallDistribution.module.css';
@@ -167,7 +167,7 @@ class CallDistribution extends Component {
                     }).catch((e) => {
                         Modal.error({
                             title: "Error updating call distribution",
-                            content: e.message,
+                            content: getErrorMessage(e),
                         });
                     }).then(()=>{
                         this.fetchData(()=>{self.setState({editing: false})})

--- a/src/containers/Callers/EditCallerForm.js
+++ b/src/containers/Callers/EditCallerForm.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Button, Checkbox, Form, Input, message } from 'antd';
 import { authHeader } from '../../_util/auth/auth-header';
-import axios from '../../_util/axios-api';
+import axios, { getErrorMessage } from '../../_util/axios-api';
 
 class EditCaller extends Component {
 
@@ -165,7 +165,7 @@ class EditCaller extends Component {
           })
         }).catch((e) => {
             this.setState({saving: false}, ()=>{
-                message.error(`Error saving: ${e.message}`);
+                message.error(`Error saving: ${getErrorMessage(e)}`);
             })
         })
       }

--- a/src/containers/Callers/HistoryPanel.js
+++ b/src/containers/Callers/HistoryPanel.js
@@ -14,7 +14,7 @@ import {
 } from 'antd';
 import { authHeader } from '../../_util/auth/auth-header';
 import { HistoryType } from './constants'
-import axios from '../../_util/axios-api';
+import axios, { getErrorMessage } from '../../_util/axios-api';
 
 const sendNotification = (callerId) => {
     const requestOptions = {
@@ -25,7 +25,7 @@ const sendNotification = (callerId) => {
     axios(requestOptions).then((response)=>{
       message.success("Notification sent successfully.")
     }).catch((e) => {
-        message.error(`Notification failed to send: ${e.message}`);
+        message.error(`Notification failed to send: ${getErrorMessage(e)}`);
     })
 }
 

--- a/src/containers/Representative/Representative.js
+++ b/src/containers/Representative/Representative.js
@@ -5,7 +5,7 @@ import { Button, Card, Col, Form, Input, List, Modal, Row, Skeleton, Spin, Typog
 import OfficeModal from './OfficeModal';
 import StatusFormItem from './StatusFormItem';
 
-import axios from '../../_util/axios-api';
+import axios, { getErrorMessage } from '../../_util/axios-api';
 import { displayName } from '../../_util/district';
 import { authHeader } from '../../_util/auth/auth-header';
 
@@ -147,7 +147,7 @@ class Representative extends Component {
             }).catch((e) => {
                 Modal.error({
                     title: "Error updating district",
-                    content: e.message,
+                    content: getErrorMessage(e),
                 });
             }).then(()=>{
                 this.fetchDistrictDetails(()=>{self.setState({editing: false})})
@@ -344,7 +344,7 @@ class Representative extends Component {
                     }).catch((e) => {
                         Modal.error({
                             title: "Error removing office",
-                            content: e.message,
+                            content: getErrorMessage(e),
                         });
                     }).then(()=>{
                         that.fetchDistrictDetails(()=>{that.setState({editing: false})})
@@ -385,7 +385,7 @@ class Representative extends Component {
             }).catch((e) => {
                 Modal.error({
                     title: "Error adding office",
-                    content: e.message,
+                    content: getErrorMessage(e),
                 });
             }).then(()=>{
                 this.fetchDistrictDetails(()=>{this.setState({editing: false})})
@@ -419,7 +419,7 @@ class Representative extends Component {
             }).catch((e) => {
                 Modal.error({
                     title: "Error updating office",
-                    content: e.message,
+                    content: getErrorMessage(e),
                 });
             }).then(()=>{
                 this.fetchDistrictDetails(()=>{this.setState({editing: false})})

--- a/src/containers/SignUp/SignUp.js
+++ b/src/containers/SignUp/SignUp.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Button, Col, Empty, Form, Icon, Input, Modal, Row, Spin, Typography, TreeSelect } from 'antd';
 import { withRouter, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
-import axios from '../../_util/axios-api';
+import axios, { getErrorMessage } from '../../_util/axios-api';
 import groupBy from '../../_util/groupBy';
 import { authHeader } from '../../_util/auth/auth-header';
 import { displayName } from '../../_util/district';
@@ -83,7 +83,7 @@ class SignUp extends Component {
                     }).catch((e) => {
                         Modal.error({
                             title: "Error Signing Up",
-                            content: `${e.response.data.message}`
+                            content: `${getErrorMessage(e)}`
                         });
                         this.setState({submissionStage: "unsubmitted"})
                     })


### PR DESCRIPTION
When user tries to save invalid data, such as a duplicate key, show the
detailed message returned by the API, instead of just "HTTP 400 Bad
Request".